### PR TITLE
docs: add PDM as a supported service

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,7 @@ The HTTPS is the universally accepted backend and supports the most authenticati
 
 ### Username and Password
 
-!!! info "Supported Services: PVE, PMG, PBS"
+!!! info "Supported Services: PVE, PMG, PBS, PDM"
 
 Password authentication is the default authentication method and what is used by the web UI. To use this authentication method, the following data is needed:
 
@@ -45,7 +45,7 @@ Renewal also does not require OTP codes, so once initially authenticated with an
 
 ### API Token
 
-!!! info "Supported Services: PVE, PBS"
+!!! info "Supported Services: PVE, PBS, PDM"
 
 The API Token allows stateless interaction with the Proxmox service as well as independent permissions and more flexibility in credential lifecycle management. Abused/leaked API Tokens can be disabled independent of the account with which they are associated and multiple API Tokens can be created for a user, allowing each use its own API Token with only its needed permissions which can be independently managed.
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -30,7 +30,7 @@ e.g. `proxmox = ProxmoxAPI('<host_ip_or_domain>', user='<username>', backend='op
 
 ### Changing Ports
 
-Proxmoxer (when using the https backend) will use the default port for the selected service to connect to the service. If you need to connect on a different port, adding either the `port=<port_number>` parameter or adding `:<port>` to the host can be used. A port in the host will override the `port` parameter. The `port` parameter can also be used for the SSH-based backends to change the port used to establish a SSH connection.
+Proxmoxer (when using the https backend) will use the default port for the selected service to connect to the service (e.g. 8006 for PVE/PMG, 8007 for PBS, 8443 for PDM). If you need to connect on a different port, adding either the `port=<port_number>` parameter or adding `:<port>` to the host can be used. A port in the host will override the `port` parameter. The `port` parameter can also be used for the SSH-based backends to change the port used to establish a SSH connection.
 
 ## Making API Calls
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Below are the Proxmox services supported by this library.[^1]
 * PVE ([API Spec](https://pve.proxmox.com/pve-docs/api-viewer/index.html))
 * PMG ([API Spec](https://pmg.proxmox.com/pmg-docs/api-viewer/index.html))
 * PBS ([API Spec](https://pbs.proxmox.com/docs/api-viewer/index.html))
+* PDM ([API Spec](https://pdm.proxmox.com/docs/api-viewer/index.html))
 
 ## Supported Backends (Connection Methods) {#supported-backends}
 


### PR DESCRIPTION
Register PDM (Proxmox Datacenter Manager) in the supported services list, document its default port (8443), and mark password and API token authentication as supported.

I finally found the time to update the documentation. This PR follows the PR I made on the proxmoxer repository adding PDM support ([#225](https://github.com/proxmoxer/proxmoxer/pull/225)).